### PR TITLE
Remove stale @zendesk/talk CODEOWNERS reference

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # CODEOWNERS file
 # This file defines who should review code changes in this repository.
 
-* @zendesk/talk


### PR DESCRIPTION
Remove `@zendesk/talk` as the sole code owner. This GitHub team corresponds to an org group in ZIG that is being removed for being stale (it no longer has any valid child groups).

If this repo needs a new owner, please suggest a replacement team in review.

See [org.yaml in ZIG](https://github.com/zendesk/zendesk-identity-governance/blob/c6fb2e1c3673875e2217e20370e60d35e8989406/org.yaml#L428C11-L428C16) for more information.

JIRA: https://zendesk.atlassian.net/browse/FSEC-10759